### PR TITLE
Allow GitHub Action to be run on-demand

### DIFF
--- a/.github/workflows/run_scripts.yaml
+++ b/.github/workflows/run_scripts.yaml
@@ -2,6 +2,7 @@ name: Run Scripts
 on:
   schedule:
     - cron: "0 14 * * 3" # Every Wednesday at 2PM UTC (10AM EST)
+  workflow_dispatch:  # This job can also be run on-demand.
 jobs:
   Run-Import-Bot:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Sometimes you just don't wanna wait until Wednesday...

Like https://github.com/internetarchive/openlibrary/actions/workflows/cron_watcher.yml ...
You will get a `Run workflow` button that will let you run anytime on any branch.